### PR TITLE
Ensure `lib` instead of `src` is in package to fix installation

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+*.eslint*
+src/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Command line tool interface for Fury.js",
   "bin": {
     "fury": "lib/fury.js"


### PR DESCRIPTION
Without an npmignore, npm will ignore `lib/` if `src/` exists.

/c @w-vi 

This fix can be verified with pack:

#### Before

```shell
$ npm pack
fury-cli-0.1.0.tgz

$ tar xvf fury-cli-0.1.0.tgz 
x package/package.json
x package/.npmignore
x package/README.md
x package/LICENSE
x package/.eslintrc
x package/src/fury.js
```

#### After

```shell
$ npm pack 
fury-cli-0.1.0.tgz

$ tar xvf fury-cli-0.1.0.tgz 
x package/package.json
x package/.npmignore
x package/README.md
x package/LICENSE
x package/lib/fury.js
x package/lib/fury.map
```

Fixes #2