### PR TITLE
Allow loading custom fury adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ $ fury --help
     -f, --format [format]  output format
     -l, --validate         validate input only
     -s, --sourcemap        Export sourcemaps into API Elements parse result
+    --adapter [adapter]    Load a fury adapter
 ```
 
 #### Input Formats

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Command line tool interface for Fury.js",
   "bin": {
     "fury": "lib/fury.js"

--- a/src/fury.js
+++ b/src/fury.js
@@ -124,6 +124,7 @@ if (require.main === module) {
     .option('-f, --format [format]', 'output format', 'application/vnd.refract.parse-result+json')
     .option('-l, --validate', 'validate input only')
     .option('-s, --sourcemap', 'Export sourcemaps into API Elements parse result')
+    .option('--adapter [adapter]', 'Load a fury adapter')
     .arguments('<input> [output]')
     .action((inputArgument, outputArgument) => {
       input = inputArgument;
@@ -135,6 +136,10 @@ if (require.main === module) {
   if (input === undefined) {
     console.error('Input not given.');
     process.exit(3);
+  }
+
+  if (commander.adapter) {
+    fury.use(require(commander.adapter));
   }
 
   const furyCLI = new FuryCLI(input, output, commander.format,


### PR DESCRIPTION
This PR adds an `--adapter` option so you can dynamically load an adapter that is previously unknown to Fury.

Example:

There is a `fury-adapter-foo` adapter which supports serialisation and parsing for custom `foo` format.

```shell
$ npm install fury-cli
$ npm install fury-adapter-foo
$ fury --adapter fury-adapter-foo add.foo
$ fury --adapter fury-adapter-foo add.apib -f application/foo+json
```