### PR TITLE
Update to Fury Beta 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   and `application/vnd.refract.parse-result+yaml; version=0.6` were added which
   allows you to serialise to the Refract 0.6 JSON/YAML Serialisation format.
 
+### Bug Fixes
+
+- Prevent fury-cli from erroring when handling annotations that do not contain
+  a code.
+
 ## 0.3.0 - 2017-06-11
 
 - Update to Fury 3.0.0-beta.3 which updates Refract JSON serialisation rules to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Master
+
+### Enhancements
+
+- The output format `application/vnd.refract.parse-result+json; version=0.6`
+  and `application/vnd.refract.parse-result+yaml; version=0.6` were added which
+  allows you to serialise to the Refract 0.6 JSON/YAML Serialisation format.
+
 ## 0.3.0 - 2017-06-11
 
 - Update to Fury 3.0.0-beta.3 which updates Refract JSON serialisation rules to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Master
+## 0.4.0
 
 ### Enhancements
 

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
     "commander": "^2.9",
     "cardinal": "^1.0.0",
     "js-yaml": "^3.6",
-    "fury": "3.0.0-beta.3",
-    "fury-adapter-swagger": "^0.12.0",
-    "fury-adapter-apib-parser": "^0.8.0",
-    "fury-adapter-apib-serializer": "^0.4.0",
-    "fury-adapter-apiary-blueprint-parser": "3.0.0-beta.1"
+    "fury": "3.0.0-beta.4",
+    "fury-adapter-swagger": "^0.13.0",
+    "fury-adapter-apib-parser": "^0.9.0",
+    "fury-adapter-apib-serializer": "^0.5.0",
+    "fury-adapter-apiary-blueprint-parser": "3.0.0-beta.2"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "fury-adapter-swagger": "^0.13.0",
     "fury-adapter-apib-parser": "^0.9.0",
     "fury-adapter-apib-serializer": "^0.5.0",
-    "fury-adapter-apiary-blueprint-parser": "3.0.0-beta.2"
+    "fury-adapter-apiary-blueprint-parser": "3.0.0-beta.2",
+    "minim": "^0.19.0"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Command line tool interface for Fury.js",
   "bin": {
     "fury": "lib/fury.js"

--- a/src/fury.js
+++ b/src/fury.js
@@ -69,11 +69,19 @@ class FuryCLI {
     }
 
     result.warnings.forEach((annotation) => {
-      process.stderr.write(`warning: (${annotation.code.toValue()})  ${annotation.toValue()}\n`);
+      if (annotation.code) {
+        process.stderr.write(`warning: (${annotation.code.toValue()})  ${annotation.toValue()}\n`);
+      } else {
+        process.stderr.write(`warning: ${annotation.toValue()}\n`);
+      }
     });
 
     result.errors.forEach((annotation) => {
-      process.stderr.write(`error: (${annotation.code.toValue()})  ${annotation.toValue()}\n`);
+      if (annotation.code) {
+        process.stderr.write(`error: (${annotation.code.toValue()})  ${annotation.toValue()}\n`);
+      } else {
+        process.stderr.write(`error: ${annotation.toValue()}\n`);
+      }
     });
 
     if (result.errors.length > 0) {

--- a/src/fury.js
+++ b/src/fury.js
@@ -6,6 +6,7 @@ import yaml from 'js-yaml';
 import commander from 'commander';
 import { highlight } from 'cardinal';
 import theme from 'cardinal/themes/tomorrow-night';
+import JSON06Serialiser from 'minim/lib/serialisers/json-0.6';
 import fury from 'fury';
 import swagger from 'fury-adapter-swagger';
 import apiBlueprintParser from 'fury-adapter-apib-parser';
@@ -87,6 +88,16 @@ class FuryCLI {
       this.validateResult(result);
     } else if (this.outputFormat === 'application/vnd.refract.parse-result+yaml') {
       const output = yaml.dump(fury.minim.toRefract(result));
+      this.write(output);
+      this.validateResult(result);
+    } else if (this.outputFormat === 'application/vnd.refract.parse-result+json; version=0.6') {
+      const serialiser = new JSON06Serialiser(fury.minim);
+      const output = JSON.stringify(serialiser.serialise(result), null, 2);
+      this.write(output, true);
+      this.validateResult(result);
+    } else if (this.outputFormat === 'application/vnd.refract.parse-result+yaml; version=0.6') {
+      const serialiser = new JSON06Serialiser(fury.minim);
+      const output = yaml.dump(serialiser.serialise(result));
       this.write(output);
       this.validateResult(result);
     } else {


### PR DESCRIPTION
Update to Fury Beta 4 along with the following changes:

- Fixes a bug where annotations without codes would cause errors. This would happen for adapters such as the Apiary Blueprint adapter that doesn't supply codes.
- Adds support for serialising to both 1.0 and 0.6 Refract JSON:

  ```shell
  $ fury test.apib -f 'application/vnd.refract.parse-result+json; version=0.6'
  $ fury test.apib -f 'application/vnd.refract.parse-result+json'
  ```