### PR TITLE
Add interactive shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Master
+## 0.6.0
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Master
+
+### Enhancements
+
+- Added a `--shell` option, this allows you to launch a interactive repl where
+  you can interact with the parse result.
+
 ## 0.5.2
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ $ fury --help
     -f, --format [format]  output format
     -l, --validate         validate input only
     -s, --sourcemap        Export sourcemaps into API Elements parse result
+    --shell                Launch an interactive shell to interact with parse result
     --adapter [adapter]    Load a fury adapter
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-cli",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Command line tool interface for Fury.js",
   "bin": {
     "fury": "lib/fury.js"


### PR DESCRIPTION
I found it was easier to develop this feature so I could quickly test some minim iteration code on the go than it was to write the code separately having to load fury and the adapters.

This adds a `--shell` option launching a REPL to iterate with the parse result elements. Great for testing minim features and behaviours.

![messages image 298442392](https://user-images.githubusercontent.com/44164/36000639-7c759ca0-0d1b-11e8-910e-5f53d84b40ff.png)

```shell
$ fury --shell fixtures/examples/swagger/instagram.yaml 
> parseResult.api.resourceGroups.reduce((resources, group) => resources.concat(group.resources.elements), parseResult.api.resources.elements)
[ Resource {
    _meta: constructor { content: [], _storedElement: 'object' },
    _attributes: constructor { content: [Array], _storedElement: 'object' },
    content: [ [Object] ],
    _storedElement: 'resource' },
  Resource {
    _meta: constructor { content: [], _storedElement: 'object' },
    _attributes: constructor { content: [Array], _storedElement: 'object' },
    content: [ [Object] ],
...
```