### PR TITLE
Revert "fix(package): update cardinal to version 2.1.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.23.0",
-    "cardinal": "^2.1.1",
+    "cardinal": "^1.0.0",
     "commander": "^2.9",
     "fury": "3.0.0-beta.6",
     "fury-adapter-apiary-blueprint-parser": "3.0.0-beta.3",


### PR DESCRIPTION
cardinal 2.1.1 is not dependency tracked and thus we cannot be using it until it is.

Reverts apiaryio/fury-cli#20