### PR TITLE
Fix loading API Elements as source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Master
+
+### Bug Fixes
+
+- Fixes an exception being raised when trying to pass API Elements document to
+  Fury CLI as source.
+
 ## 0.8.0
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Master
+## 0.8.1
 
 ### Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Command line tool interface for Fury.js",
   "bin": {
     "fury": "lib/fury.js"

--- a/src/fury.js
+++ b/src/fury.js
@@ -77,7 +77,7 @@ class FuryCLI {
     }
 
     if (isRefract(source)) {
-      const result = fury.minim.deserialise(JSON.parse(source));
+      const result = fury.load(JSON.parse(source));
       this.handleResult(result, source);
       return;
     }


### PR DESCRIPTION
Some users are seeing an error:

node_modules/.bin/fury --adapter @apiaryio/fury-adapter-application-ast -f application/apiary-ast elq.refract.json
/home/wvi/src/tmp/appast-size/node_modules/fury-cli/lib/fury.js:138
        var result = _fury2.default.minim.deserialise(JSON.parse(source));
                                          ^

TypeError: _fury2.default.minim.deserialise is not a function
    at FuryCLI.run (/home/wvi/src/tmp/appast-size/node_modules/fury-cli/lib/fury.js:138:43)
    at Object.<anonymous> (/home/wvi/src/tmp/appast-size/node_modules/fury-cli/lib/fury.js:273:11)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Function.Module.runMain (module.js:693:10)
    at startup (bootstrap_node.js:191:16)
    at bootstrap_node.js:612:3