### PR TITLE
Release 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Master
+## 0.8.2 (2018-09-07)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Master
+
+### Enhancements
+
+This update now uses fury-adapter-swagger 0.20.0. Please see
+[fury-adapter-swagger 0.20.0](https://github.com/apiaryio/fury-adapter-swagger/releases/tag/v0.20.0)
+for the list of changes.
+
 ## 0.8.1
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Command line tool interface for Fury.js",
   "bin": {
     "fury": "lib/fury.js"


### PR DESCRIPTION
### Enhancements

This update now uses fury-adapter-swagger 0.20.0. Please see [fury-adapter-swagger 0.20.0](https://github.com/apiaryio/fury-adapter-swagger/releases/tag/v0.20.0) for the list of changes.